### PR TITLE
i wonder if social image is seen on meta redirect

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,7 @@
 <!doctype html>
 <meta charset=utf-8>
-<title>redirect</title>
-<meta http-equiv=refresh content="0; url=/">
-<link rel=help href="https://github.com/webmural/redirect">
+<title>Tape Stickers Debut on Kickstarter</title>
+<meta property="og:image" content="https://user-images.githubusercontent.com/949985/89831868-8aaf2700-db2c-11ea-8ea8-1b708e31f79a.png">
+<meta property="og:image:alt" content="green tape dub">
+<meta http-equiv=refresh content="0; url=https://www.kickstarter.com/projects/ryanve/debut">
+<link rel href="https://github.com/turnupthetape/kickdubber">


### PR DESCRIPTION
with [og:image](https://user-images.githubusercontent.com/949985/89831868-8aaf2700-db2c-11ea-8ea8-1b708e31f79a.png) before [the redirect](https://www.kickstarter.com/projects/ryanve/debut)